### PR TITLE
hide/show virtual and ooc users

### DIFF
--- a/app/adapters/cats.js
+++ b/app/adapters/cats.js
@@ -79,6 +79,8 @@ CATS.Adapter.Cats = Classify({
         user.name = v['name'];
         user.role = v['virtual'] == 1 ? 'virtual' : v['role'];
         user.is_remote = v["remote"];
+        user.ooc = v['ooc'];
+        user.virtual = v['virtual'];
         if (v.affiliation) {
             user.affiliation.city = v.affiliation.city;
             user.affiliation.country = v.affiliation.country;

--- a/app/models/results_table.js
+++ b/app/models/results_table.js
@@ -15,6 +15,8 @@ CATS.Model.Results_table = Classify(CATS.Model.Entity, {
             user: null,
             affiliation: null,
             role: null,
+            ooc: 1,
+            virtual: 1,
         };
     },
 
@@ -160,7 +162,8 @@ CATS.Model.Results_table = Classify(CATS.Model.Entity, {
         var self = this;
         $.each(old_score_board, function (k, row) {
             var user = CATS.App.users[row['user']];
-            if ((self.filters.user == null || user.name.match(new RegExp(self.filters.user))) &&
+            if ((self.filters.ooc >= user.ooc && self.filters.virtual >= user.virtual) &&
+                (self.filters.user == null || user.name.match(new RegExp(self.filters.user))) &&
                 (self.filters.affiliation == null || user.some_affiliation().match(new RegExp(self.filters.affiliation))) &&
                 (self.filters.role == null || user.role.match(new RegExp(self.filters.role)))
             ) {

--- a/app/templates/filters.html
+++ b/app/templates/filters.html
@@ -69,6 +69,10 @@ if (page != 'history') {%>
             <%});%>
             </div>
         </div>
+        <div class="col-md-3">
+            <input type="checkbox" id="visible_ooc" checked> out of contest</input><br>
+            <input type="checkbox" id="visible_virtual" checked> virtual</input></p>
+        </div>
     </div>
     <div class="row">
         <div class="col-md-12">

--- a/app/view.js
+++ b/app/view.js
@@ -15,7 +15,9 @@ CATS.View = Classify({
             settings: null,
             lang: null,
             page: null,
-            el_per_page: null
+            el_per_page: null,
+            ooc: null,
+            virtual: null
         },
         name: "ViewState"
     }),
@@ -233,6 +235,14 @@ CATS.View = Classify({
                 $('#catsscore_header').html(header);
                 $('#source').val(this.source());
                 $('#skin').val(this.skin());
+            },
+            'click #visible_ooc': function(){
+                var ooc_value = $("#visible_ooc").prop("checked");
+                this.update_rank_table({ ooc: ooc_value });
+            },
+            'click #visible_virtual': function(){
+                var virtual_value = $("#visible_virtual").prop("checked");
+                this.update_rank_table({ virtual: virtual_value });
             },
             'click #add_series': function () {
                 var chart = this.current_chart(),


### PR DESCRIPTION
Теперь при разворачивании фильтров появляются, кроме всего прочего, два чекбокса: "виртуальные" и "внеконкурсные". Скрывают и показывают соответствующих участников